### PR TITLE
Map configuration updates to default FL visibility, Time Period, and layout padding

### DIFF
--- a/client/public/templates/mapping/mapping.controller.js
+++ b/client/public/templates/mapping/mapping.controller.js
@@ -488,7 +488,7 @@ angular.module('vppApp')
             id: "Bart",
             mode: w.FeatureLayer.MODE_SNAPSHOT,
             outFields: ["*"],
-            visible: true,
+            visible: false,
             infoTemplate: transitLayerInfo
         });
         BartFL.setDefinitionExpression("agencyname='BART'");
@@ -497,7 +497,7 @@ angular.module('vppApp')
             id: "Caltrain",
             mode: w.FeatureLayer.MODE_SNAPSHOT,
             outFields: ["*"],
-            visible: true,
+            visible: false,
             infoTemplate: transitLayerInfo
         });
         CaltrainFL.setDefinitionExpression("agencyname='CALTRAIN'");

--- a/client/public/templates/mapping/mapping.controller.js
+++ b/client/public/templates/mapping/mapping.controller.js
@@ -1174,7 +1174,7 @@ angular.module('vppApp')
             //$scope.OCCtimeperiod = $(this).attr('id');
             SetOccupancyRenderer($(this).attr('id').toString());
             $scope.TimePeriod = $(this).text();
-            $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.TimePeriod + " <br/>Percent of total spaces with vehicles occupying spaces </p>");
+            $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.TimePeriod + " <br/><br/>Percent of total spaces with vehicles occupying spaces </p>");
         });
 
         $('.parkTheme').on('click', function () {
@@ -1279,7 +1279,7 @@ angular.module('vppApp')
                 $("#mlegend_TotalSpaces").fadeOut(0);
                 $("#LegendNamePNL_TotalSpaces").fadeOut(0);
                 //Write in the title for the legend item.
-                $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.TimePeriod + "<br/>Percent of total spaces with vehicles occupying spaces</p>");
+                $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.TimePeriod + "<br/><br/>Percent of total spaces with vehicles occupying spaces</p>");
                 //console.log($scope.pt + " | " + $scope.selectedId);
                 break;
             case "wkndOCC":
@@ -1307,7 +1307,7 @@ angular.module('vppApp')
                 $("#mlegend_TotalSpaces").fadeOut(0);
                 $("#LegendNamePNL_TotalSpaces").fadeOut(0);
                 //Write in the title for the legend item.
-                $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.TimePeriod + " <br/> Percent of total spaces with vehicles occupying spaces </p>");
+                $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.TimePeriod + " <br/><br/>Percent of total spaces with vehicles occupying spaces </p>");
                 //console.log($scope.pt + " | " + $scope.selectedId);
                 //console.log("? should be true", $scope.TODbtn);
                 break;
@@ -1398,7 +1398,7 @@ angular.module('vppApp')
 
                     break;
                 }
-                $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.parkingType + "</b><br/>" + $scope.TimePeriod + " <br/>Percent of total spaces with vehicles occupying spaces </p>");
+                $('#LegendNamePNL_Occ').html("<p><b>" + $scope.DayType + "</b><br/>" + $scope.parkingType + "</b><br/>" + $scope.TimePeriod + " <br/><br/>Percent of total spaces with vehicles occupying spaces </p>");
 
             }).error(function (data, status) {
                 console.log("There was an error:", status);

--- a/client/public/templates/mapping/mapping.controller.js
+++ b/client/public/templates/mapping/mapping.controller.js
@@ -111,7 +111,7 @@ angular.module('vppApp')
         TPAsFLsv = 30;
         TPAsFLop = 0.3;
         $scope.legendBTN = false;
-        $scope.TimePeriod = "Early Morning (5AM)";
+        $scope.TimePeriod = "Noon (12PM)";
         $scope.TODbtn = false;
         $scope.parkingType = "Both On/Off-Street Parking";
         $scope.PTbtn = false;
@@ -1201,7 +1201,7 @@ angular.module('vppApp')
             PeakWEOffStreetOccupancyFL.hide();
 
             $scope.pt = $(this).attr('id');
-            $scope.TimePeriod = "Early Morning (5AM)";
+            $scope.TimePeriod = "Noon (12PM)";
             $scope.parkingType = "Both On/Off-Street Parking";
             switch ($scope.pt) {
             case "inventory":
@@ -1255,8 +1255,8 @@ angular.module('vppApp')
                 //console.log($scope.pt + " | " + $scope.selectedId);
                 break;
             case "wkdayOCC":
-                $scope.TimePeriod = "Early Morning (5AM)";
-                SetOccupancyRenderer("Occupancy_5am");
+                $scope.TimePeriod = "Noon (12PM)";
+                SetOccupancyRenderer("Occupancy_12pm");
                 $scope.TODbtn = true;
                 $scope.DayType = "Weekday Occupancy";
 
@@ -1283,8 +1283,8 @@ angular.module('vppApp')
                 //console.log($scope.pt + " | " + $scope.selectedId);
                 break;
             case "wkndOCC":
-                $scope.TimePeriod = "Early Morning (5AM)";
-                SetOccupancyRenderer("Occupancy_5am");
+                $scope.TimePeriod = "Noon (12PM)";
+                SetOccupancyRenderer("Occupancy_12pm");
                 $scope.TODbtn = true;
                 $scope.DayType = "Weekend Occupancy";
 
@@ -1346,7 +1346,7 @@ angular.module('vppApp')
         });
 
         function showPeak(a) {
-            $scope.TimePeriod = "Early Morning (5AM)";
+            $scope.TimePeriod = "Noon (12PM)";
             $scope.ptp = a;
             $http({
                 url: publicDataURL + '/data/getPeak?sa=' + $scope.selectedId + '&pt=' + $scope.ptp,
@@ -1418,7 +1418,7 @@ angular.module('vppApp')
 
 
         $('.occ').on('click', function () {
-            $scope.TimePeriod = "Early Morning (5AM)";
+            $scope.TimePeriod = "Noon (12PM)";
             $scope.TODbtn = true;
             //$("#PeakTypeOptionsBTN").fadeOut(0);
             $scope.PTbtn = false;
@@ -1879,7 +1879,7 @@ angular.module('vppApp')
 
                 //turn on time button
                 $scope.timeButton = true;
-                $scope.TimePeriod = "Early Morning (5AM)";
+                $scope.TimePeriod = "Noon (12PM)";
                 //turn off the peak button
                 $scope.peakButton = false;
             } else if (view === "peak") {

--- a/client/public/templates/mapping/mapping.html
+++ b/client/public/templates/mapping/mapping.html
@@ -713,13 +713,13 @@
                         </div>
                         <div class="adl">
                             <p>
-                                <input id="bartSwitch" type="checkbox" data-size="mini" name="BartFL" checked="true">
+                                <input id="bartSwitch" type="checkbox" data-size="mini" name="BartFL">
                                 <span class="pad-left-m LayerLBLs">BART</span>
                             </p>
                         </div>
                         <div class="adl">
                             <p>
-                                <input id="caltrainSwitch" type="checkbox" data-size="mini" name="CaltrainFL" checked="true">
+                                <input id="caltrainSwitch" type="checkbox" data-size="mini" name="CaltrainFL">
                                 <span class="pad-left-m LayerLBLs">Caltrain</span>
                             </p>
                         </div>

--- a/client/public/templates/mapping/mapping.html
+++ b/client/public/templates/mapping/mapping.html
@@ -61,7 +61,7 @@
                 </div>
 
             </div>
-            <div id="LegendNamePNL_Occ" class="pad-bottom-sm pad-top-m collapse">
+            <div id="LegendNamePNL_Occ" class="pad-bottom-m pad-top-m collapse">
 
             </div>
             <div id="mlegend_Occ" class="collapse">


### PR DESCRIPTION
Removed configuration settings for the BART and Caltrain feature layers that were visible by default.  These feature layers will be 'OFF' by default.  This change addresses user complaints that the default display of BART and Caltrain stations on the initial map view overshadowed the Study Areas.

Changed LegendNamePNL_Occ class from "pad-bottom-sm" to  "pad-bottom-m".  Panel content appears more distinct and readily identified upon scanning the legend.

Added line breaks to LegendNamePNL_Occ html just before text reading, "Percent of total…" to provide additional separation.

Default Time Period changed from 'Early Morning (5AM)' to 'Noon (12PM)'.  Addresses user complaint that the 5AM time period is less relevant than noon.
